### PR TITLE
switching to using findup-sync to find local node_modules

### DIFF
--- a/lib/listDirectories.js
+++ b/lib/listDirectories.js
@@ -2,44 +2,54 @@ const debug = require('debug')('meta:listDirectories');
 const fs = require('fs');
 const path = require('path');
 const union = require('lodash.union');
+const findupSync = require('findup-sync');
 
 const regex = /^meta-.*/;
 
-module.exports = (dir) => {
-
-  const localdir = path.join(process.cwd(), 'node_modules');
+module.exports = dir => {
+  const localdir = findupSync('node_modules', { cwd: process.cwd() });
 
   debug(`listing all child directories matching ${regex} in ${localdir}`);
 
   var localPlugins, localPluginsFullPath;
 
   try {
-    localPlugins = fs.readdirSync(localdir).filter((file) => {
-      return (fs.statSync(path.join(localdir, file)).isDirectory() || fs.lstatSync(path.join(localdir, file)).isSymbolicLink()) && regex.test(file);
+    localPlugins = fs.readdirSync(localdir).filter(file => {
+      return (
+        (fs.statSync(path.join(localdir, file)).isDirectory() ||
+          fs.lstatSync(path.join(localdir, file)).isSymbolicLink()) &&
+        regex.test(file)
+      );
     });
 
-    localPluginsFullPath = localPlugins.map((r) => { return path.resolve(localdir, r); }); 
+    localPluginsFullPath = localPlugins.map(r => {
+      return path.resolve(localdir, r);
+    });
 
     debug(`found local plugins ${localPlugins}`);
-
   } catch (error) {
     debug(`no meta plugins found in ${localdir}`);
     localPlugins = [];
   }
 
   debug(`listing all child directories matching ${regex} in ${dir}`);
-  
-  const globalPlugins = fs.readdirSync(dir).filter((file) => {
-    return (fs.statSync(path.join(dir, file)).isDirectory() || ! fs.lstatSync(path.join(dir, file)).isSymbolicLink()) 
-          && regex.test(file)
-          && localPlugins.indexOf(file) === -1;
+
+  const globalPlugins = fs.readdirSync(dir).filter(file => {
+    return (
+      (fs.statSync(path.join(dir, file)).isDirectory() ||
+        !fs.lstatSync(path.join(dir, file)).isSymbolicLink()) &&
+      regex.test(file) &&
+      localPlugins.indexOf(file) === -1
+    );
   });
 
   debug(`found global plugins ${globalPlugins}`);
-  
-  const globalPluginsFullPath = globalPlugins.map((r) => { return path.resolve(dir, r); });
 
-  return union(localPluginsFullPath, globalPluginsFullPath).sort((a, b) => { 
+  const globalPluginsFullPath = globalPlugins.map(r => {
+    return path.resolve(dir, r);
+  });
+
+  return union(localPluginsFullPath, globalPluginsFullPath).sort((a, b) => {
     if (path.basename(a) < path.basename(b)) return -1;
     if (path.basename(a) > path.basename(b)) return 1;
     return 0;

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "commander": "mateodelnorte/commander.js",
     "cross-env": "^3.1.4",
     "debug": "^2.3.3",
+    "findup-sync": "^1.0.0",
     "lodash.union": "^4.6.0",
     "meta-exec": "^0.0.5",
     "meta-git": "^0.0.28",


### PR DESCRIPTION
it works in more contexts, it finds the closest node_modules directory up the directory tree.

When integrating meta with microsvc, it was failing to find the installed plugins otherwise.