### PR TITLE
Add meta-config plugin

### DIFF
--- a/.meta
+++ b/.meta
@@ -18,7 +18,7 @@
     "plugins/meta-template": "git@github.com:patrickleet/meta-template.git",
     "plugins/meta-yarn": "git@github.com:mateodelnorte/meta-yarn.git",
     "plugins/symlink-meta-dependencies": "git@github.com:mateodelnorte/symlink-meta-dependencies.git",
-    "plugins/meta-config": "git@github.com:dorner/meta-config.git"
+    "plugins/meta-configure": "git@github.com:dorner/meta-configure.git"
   },
   "templates": {
     "templates/meta-plugin": "git@github.com:patrickleet/meta-template-meta-plugin.git"

--- a/.meta
+++ b/.meta
@@ -17,7 +17,8 @@
     "plugins/meta-project": "git@github.com:mateodelnorte/meta-project.git",
     "plugins/meta-template": "git@github.com:patrickleet/meta-template.git",
     "plugins/meta-yarn": "git@github.com:mateodelnorte/meta-yarn.git",
-    "plugins/symlink-meta-dependencies": "git@github.com:mateodelnorte/symlink-meta-dependencies.git"
+    "plugins/symlink-meta-dependencies": "git@github.com:mateodelnorte/symlink-meta-dependencies.git",
+    "plugins/meta-config": "git@github.com:dorner/meta-config.git"
   },
   "templates": {
     "templates/meta-plugin": "git@github.com:patrickleet/meta-template-meta-plugin.git"

--- a/README.md
+++ b/README.md
@@ -54,6 +54,18 @@ Remove unwanted untracked files on all repos with `meta git clean -fd`:
 
  [![asciicast](https://asciinema.org/a/0s8f9wp49nfilzpub3tnf9shg.png)](https://asciinema.org/a/0s8f9wp49nfilzpub3tnf9shg)
 
+## Configuration
+
+You can configure meta with the `meta-config` plugin. This provides options
+for other plugins.
+
+Current options:
+
+```bash
+  # Skip the confirmation dialog when running inside a subfolder / subproject
+  meta config useParentMeta true
+```
+
 # really working with meta
 
 ## plugins

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Remove unwanted untracked files on all repos with `meta git clean -fd`:
 
 ## Configuration
 
-You can configure meta with the `meta-config` plugin. This provides options
+You can configure meta with the `meta-configure` plugin. This provides options
 for other plugins.
 
 Current options:


### PR DESCRIPTION
This plugin allows you to use `meta config key value` to save configuration to the meta file so that other plugins can use this. First one I want to update is `get-meta-file`.

You can fork the repo and change the URL to your own if you think it will be easier to manage.