### PR TITLE
Get directories from global directory instead of relative directory

### DIFF
--- a/bin/meta
+++ b/bin/meta
@@ -6,13 +6,16 @@ const fs = require('fs');
 const listDirectories = require('../lib/listDirectories');
 const path = require('path');
 const registerPlugin = require('../lib/registerPlugin');
+const { execSync } = require('child_process');
 
 process.on('uncaughtException', (err) => {
   console.error(err);
   process.exit(1);
 });
 
-const dirs = listDirectories(path.join(path.resolve(__dirname), '..', 'node_modules'));
+const globalDirPrefix = execSync('npm config get prefix').toString().trim();
+const globalDir = `${globalDirPrefix}/lib/node_modules`;
+const dirs = listDirectories(globalDir);
 
 const program = require('commander')
   .version(require('../package.json').version);
@@ -24,7 +27,7 @@ dirs.forEach(registerPlugin.bind(this, program));
 const inMetaDir = fs.existsSync(path.join(process.cwd(), '.meta'));
 
 if ( inMetaDir) {
-  const metagit = require('meta-git');  
+  const metagit = require('meta-git');
   metagit.update({ dryRun: true });
 }
 

--- a/lib/listDirectories.js
+++ b/lib/listDirectories.js
@@ -6,6 +6,22 @@ const findupSync = require('findup-sync');
 
 const regex = /^meta-.*/;
 
+const getModulesInDirectory = (dir, foundFiles=[]) => {
+  let files = fs.readdirSync(dir);
+  files.forEach((file) => {
+    if (file.startsWith('@')) {
+      files = files.concat(fs.readdirSync(`${dir}/${file}`));
+    }
+  });
+  return files.filter((file) => {
+    return (
+    (fs.statSync(path.join(dir, file)).isDirectory() ||
+      fs.lstatSync(path.join(dir, file)).isSymbolicLink()) &&
+    regex.test(file) && !foundFiles.includes(file)
+  );
+  });
+};
+
 module.exports = dir => {
   const localdir = findupSync('node_modules', { cwd: process.cwd() });
 
@@ -14,13 +30,7 @@ module.exports = dir => {
   var localPlugins, localPluginsFullPath;
 
   try {
-    localPlugins = fs.readdirSync(localdir).filter(file => {
-      return (
-        (fs.statSync(path.join(localdir, file)).isDirectory() ||
-          fs.lstatSync(path.join(localdir, file)).isSymbolicLink()) &&
-        regex.test(file)
-      );
-    });
+    localPlugins = getModulesInDirectory(localdir);
 
     localPluginsFullPath = localPlugins.map(r => {
       return path.resolve(localdir, r);
@@ -34,14 +44,7 @@ module.exports = dir => {
 
   debug(`listing all child directories matching ${regex} in ${dir}`);
 
-  const globalPlugins = fs.readdirSync(dir).filter(file => {
-    return (
-      (fs.statSync(path.join(dir, file)).isDirectory() ||
-        !fs.lstatSync(path.join(dir, file)).isSymbolicLink()) &&
-      regex.test(file) &&
-      localPlugins.indexOf(file) === -1
-    );
-  });
+  const globalPlugins = getModulesInDirectory(dir, localPlugins);
 
   debug(`found global plugins ${globalPlugins}`);
 


### PR DESCRIPTION
Currently, at least on Mac OSX, meta is not searching in the right directory for globally installed plugins. E.g. on my computer, it's looking in `/usr/local/lib/node_modules/meta/node_modules` but the actual location it should be looking is `/usr/local/Cellar/node/10.11.0/lib/node_modules`.

This is because I have a plugin which will not necessarily be in meta's node_modules list, but I also want to use it for projects which *do not use NodeJS*. I'd like my plugin to be installed globally the same way meta is.

Another issue here is that this does not respect namespacing (if I have a module called @flipp/meta-sync, it won't be picked up). Both issues should be fixed with this PR.

Before this is merged, I'm curious what the meaning of the original "global" check is? `path.join(path.resolve(__dirname), '..', 'node_modules'` This doesn't seem global to me at all?