### PR TITLE
fix: change "main" module to avoid shebang

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "meta",
   "version": "1.0.62",
   "description": "tool for turning many repos into a meta repo. why choose many repos or a monolithic repo, when you can have both with a meta repo?",
-  "main": "./bin/meta",
+  "main": "index.js",
   "bin": {
     "meta": "./bin/meta"
   },


### PR DESCRIPTION
Shebangs prevent BundlePhobia from calculating the bundled size.

https://bundlephobia.com/result?p=meta