### PR TITLE
fix: remove "npm root" command

### DIFF
--- a/lib/findPlugins.js
+++ b/lib/findPlugins.js
@@ -31,16 +31,18 @@ module.exports = (cwd, searchDir = 'node_modules') => {
   }
 
   // Search relative to every directory in $NODE_PATH.
-  const root = cp.execSync('npm root').toString().trim();
-  const globalRoot = cp.execSync('npm root -g').toString().trim();
-  const defaultRoots = `${root}:${globalRoot}`;
-
-  (process.env.NODE_PATH || defaultRoots).split(':').forEach(cwd =>
-    findNearbyPlugins(cwd, onPlugin)
-  );
+  const globalRoots = process.env.NODE_PATH || getDefaultGlobalRoot();
+  globalRoots.split(':').forEach(cwd => findNearbyPlugins(cwd, onPlugin));
 
   return plugins;
 };
+
+function getDefaultGlobalRoot() {
+  return cp
+    .execSync('npm root -g')
+    .toString()
+    .trim();
+}
 
 /** Check a directory for potentially-scoped /^meta-/ packages */
 function findNearbyPlugins(cwd, onPlugin) {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,17 @@
   "bin": {
     "meta": "./bin/meta"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
+  },
   "scripts": {
     "commit": "git-cz",
     "clean": "meta-npm clean",
@@ -51,6 +62,7 @@
   "dependencies": {
     "commander": "mateodelnorte/commander.js",
     "debug": "^2.3.3",
+    "husky": "^1.2.0",
     "meta-git": "^0.0.33",
     "meta-init": "^0.0.5",
     "meta-loop": "^0.0.8",
@@ -62,6 +74,7 @@
     "commitizen": "^3.0.5",
     "cz-conventional-changelog": "^2.1.0",
     "jest": "^23.6.0",
+    "lint-staged": "^8.1.0",
     "meta-gh": "^0.0.5",
     "meta-npm": "0.0.28",
     "meta-yarn": "^0.0.5",


### PR DESCRIPTION
Unless I am missing something important, the "npm root" command (without -g) always prints the nearest "node_modules" directory, which is already covered when searching every parent directory.

I also moved the command into a new `getDefaultGlobalRoot` function so we can avoid spawning a child process when `process.env.NODE_PATH` is truthy.