### PR TITLE
ci: use Travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,24 @@
 language: node_js
-cache:
-  directories:
-    - ~/.npm
+node_js:
+  - '8'
+  - '10'
+  - 'node'
+cache: npm
 notifications:
   email: false
-node_js:
-  - 8
-  - 10
-  - 11
 before_install:
-  - npm install -g greenkeeper-lockfile semantic-release codecov
-install:
-  - npm install
-before_script: greenkeeper-lockfile-update
+  - npm install -g codecov
 script:
   - npm run test
   - codecov
-after_script: greenkeeper-lockfile-upload
-after_success:
-  - semantic-release
 branches:
   except:
-    - "/^v\\d+\\.\\d+\\.\\d+$/"
+    - '/^v\d+\.\d+\.\d+$/'
+jobs:
+  include:
+    - stage: deploy
+      if: branch == master && !fork
+      node_js: '8.9.1' # pre-installed version
+      script:
+        - npm install -g semantic-release@^15
+        - semantic-release

--- a/package.json
+++ b/package.json
@@ -24,9 +24,7 @@
     "meta-link-all": "meta-npm link --all",
     "meta-link-global": "meta-npm link && npm link",
     "meta-link-all-global": "meta-npm link --all && npm link",
-    "test": "jest --coverage lib",
-    "semantic-release": "semantic-release",
-    "travis-deploy-once": "travis-deploy-once"
+    "test": "jest --coverage lib"
   },
   "repository": {
     "type": "git",
@@ -72,8 +70,6 @@
     "meta-npm": "0.0.28",
     "meta-yarn": "0.0.5",
     "prettier": "1.15.3",
-    "pretty-quick": "1.8.0",
-    "semantic-release-cli": "4.1.0",
-    "travis-deploy-once": "5.0.11"
+    "pretty-quick": "1.8.0"
   }
 }


### PR DESCRIPTION
- use `cache: npm` ([more info](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#caching-with-npm))
- replace `11` with `node` ([more info](https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions))
- remove `greenkeeper-lockfile` install
- use single quotes in `branches.except` to avoid escaped backslashes
- add a `deploy` stage to Travis ([more info](https://docs.travis-ci.com/user/build-stages/))
- `npm install` is already the default `install` script, so remove the `install` script
- remove `travis-deploy-once` and `semantic-release-cli` from the `devDependencies`