### PR TITLE
Add meta-search to third-party plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ And if you prefer the speediness of yarn, try `meta-yarn` with `npm install --sa
 
 * [meta-bump](https://github.com/patrykzurawik/meta-bump)
 * [meta-release](https://github.com/alqh/meta-release)
+* [meta-search](https://www.npmjs.com/package/meta-search)
 
 ### Available Templates
 


### PR DESCRIPTION
Hi there,

I've been using `meta` for a couple years and have written a couple utilities for internal use that I've started open-sourcing.

- NPM package: https://www.npmjs.com/package/meta-search
- GitHub: https://github.com/fluxsauce/meta-dash

The initial version includes a package search, which is useful for finding out-of-date packages.

Would it be possible to list it under the third-party plugins?

Thanks, let me know if you have any questions or concerns!